### PR TITLE
Various changes

### DIFF
--- a/sx
+++ b/sx
@@ -18,21 +18,20 @@ cleanup() {
     exit "${r:-$?}"
 }
 
+unset pid
 stty=$(stty -g)
-tty=$(ps -o tty= $$)
-
-case $tty in
-    tty*) tty=${tty#tty}
-esac
+tty=$(tty) || exit
+tty=${tty#/dev/}
+tty=${tty#tty}
 
 cfgdir=${XDG_CONFIG_HOME:-$HOME/.config}/sx
-export XAUTHORITY=${XAUTHORITY:-$cfgdir/xauthority}
+export XAUTHORITY=${XAUTHORITY:-${XDG_RUNTIME_DIR:-$HOME}/.X${tty}-authority}
 
-mkdir -p "$cfgdir" "${XAUTHORITY%/*}"
-touch "$XAUTHORITY"
+mkdir -p "$cfgdir" "${XAUTHORITY%/*}" || exit
+touch "$XAUTHORITY" || exit
 
 trap 'cleanup' EXIT
-xauth add :"$tty" MIT-MAGIC-COOKIE-1 "$(od -An -N16 -tx /dev/urandom | tr -d ' ')"
+xauth add :"$tty" MIT-MAGIC-COOKIE-1 "$(od -An -N16 -tx /dev/urandom | tr -d ' ')" || exit
 
 # Xorg will check if its SIGUSR1 disposition is SIG_IGN and use this state to
 # reply back to the parent process with SIGUSR1 as an indication it is ready

--- a/sx
+++ b/sx
@@ -18,6 +18,11 @@ cleanup() {
     exit "${r:-$?}"
 }
 
+do_sx() {
+    xauth generate "$DISPLAY" MIT-MAGIC-COOKIE-1 trusted timeout 0
+    DISPLAY=:$tty "${@:-$cfgdir/sxrc}"
+}
+
 unset pid
 stty=$(stty -g)
 tty=$(tty) || exit
@@ -25,19 +30,19 @@ tty=${tty#/dev/}
 tty=${tty#tty}
 
 cfgdir=${XDG_CONFIG_HOME:-$HOME/.config}/sx
-export XAUTHORITY=${XAUTHORITY:-${XDG_RUNTIME_DIR:-$HOME}/.X${tty}-authority}
+export XAUTHORITY=${XAUTHORITY:-$HOME/.Xauthority}
 
-mkdir -p "$cfgdir" "${XAUTHORITY%/*}" || exit
-touch "$XAUTHORITY" || exit
+mkdir -p "$cfgdir" "${XAUTHORITY%/*}"
+touch "$XAUTHORITY"
 
 trap 'cleanup' EXIT
-xauth add :"$tty" MIT-MAGIC-COOKIE-1 "$(od -An -N16 -tx /dev/urandom | tr -d ' ')" || exit
 
 # Xorg will check if its SIGUSR1 disposition is SIG_IGN and use this state to
 # reply back to the parent process with SIGUSR1 as an indication it is ready
 # to accept connections.
 # Taking advantage of this feature allows us to launch our client directly
 # from the SIGUSR1 handler and avoid the need to poll for server readiness.
-trap 'DISPLAY=:$tty "${@:-$cfgdir/sxrc}"' USR1
-(trap '' USR1 && exec Xorg :"$tty" -keeptty vt"$tty" -noreset -auth "$XAUTHORITY") & pid=$!
+trap 'do_sx' USR1
+export DISPLAY=:"$tty"
+(trap '' USR1 && exec Xorg "$DISPLAY" -keeptty vt"$tty" -noreset -auth "$XAUTHORITY") & pid=$!
 wait "$pid"


### PR DESCRIPTION
unset pid in case some idiot exported it.

use tty command instead of ps, someone may not have procps installed (minimal system) but coreutils is already required.

use tty-specific XAUTHORITY and put it in XDG_RUNTIME_DIR if available, else HOME.

add basic error handling.

comments requested on XAUTHORITY move. I think XDG_CONFIG_HOME is the wrong place to put it, but not sure whether XDG_RUNTIME_DIR should be used, or just HOME, or /tmp or something.