### PR TITLE
Made everything more readable

### DIFF
--- a/sx
+++ b/sx
@@ -1,22 +1,20 @@
-#!/bin/sh --
+#!/bin/sh
 # sx - start an xorg server
 # requires xauth Xorg /dev/urandom
 
-cleanup() {
-    if [ "$server" ] && kill -0 "$server" 2> /dev/null; then
+cleanup(){
+    if [ "$server" ] && kill -0 "$server" 2>/dev/null;then
         kill "$server"
         wait "$server"
         xorg=$?
     fi
 
-    if ! stty "$stty"; then
-        stty sane
-    fi
+    stty $oldstty || stty sane
 
     xauth remove :"$tty"
 }
 
-stty=$(stty -g)
+oldstty=$(stty -g)
 tty=$(tty)
 tty=${tty#/dev/tty}
 
@@ -27,16 +25,16 @@ mkdir -p -- "$cfgdir" "$datadir"
 export XAUTHORITY="${XAUTHORITY:-$datadir/xauthority}"
 touch -- "$XAUTHORITY"
 
-trap 'cleanup; trap "" EXIT; trap - INT; kill -s INT "$$"' INT
-trap 'cleanup; trap "" EXIT; exit "${xorg:-0}"' EXIT HUP TERM QUIT
+trap 'cleanup; trap "" EXIT; trap - INT; kill -s INT $$' INT
+trap 'cleanup; trap "" EXIT; exit ${xorg:-0}' EXIT HUP TERM QUIT
 
 # Xorg will return a USR1 signal to the parent process indicating it is ready
 # to accept connections if it inherited a USR1 signal with a SIG_IGN
 # disposition.  Consequently a client may be started directly from a USR1
 # signal handler and obviate the need to poll for server readiness.
-trap 'DISPLAY=:$tty "${@:-$cfgdir/sxrc}" & wait "$!"' USR1
+trap 'DISPLAY=:$tty "${@:-$cfgdir/sxrc}" & wait $!' USR1
 
 xauth add :"$tty" MIT-MAGIC-COOKIE-1 "$(od -An -N16 -tx /dev/urandom | tr -d ' ')"
-(trap '' USR1 && exec Xorg :"$tty" vt"$tty" -keeptty -noreset -auth "$XAUTHORITY") &
+(trap '' USR1; exec Xorg :"$tty" vt"$tty" -keeptty -noreset -auth "$XAUTHORITY") &
 server=$!
-wait "$server"
+wait $server


### PR DESCRIPTION
1. Don't use `#!/bin/sh --` it's useless
UNIX absolute file names will always start with `/`
2. Don't quote `oldstty` state
Its defined in `stty.1p` line 47, that `$(stty -g)` will never produce string that will make shell expand arguments
3. Don't use `if` ith only 1 command, it's unreadable
Having `if` with only 1 command in its body is useless and unreadable
I Changed it to `stty $oldstty || stty sane`
4. Delete useless quotes
`$!`, `$?` and `$$` will always be an int type
5. Dont use `&&` with `trap`
trap will only return non-zero if signal name is invalid