### PR TITLE
sx: use XDG_RUNTIME_DIR for xauthority file

### DIFF
--- a/sx
+++ b/sx
@@ -21,10 +21,9 @@ tty=$(tty)
 tty=${tty#/dev/tty}
 
 cfgdir=${XDG_CONFIG_HOME:-$HOME/.config}/sx
-datadir=${XDG_DATA_HOME:-$HOME/.local/share}/sx
-mkdir -p -- "$cfgdir" "$datadir"
+mkdir -p -- "$cfgdir"
 
-export XAUTHORITY="${XAUTHORITY:-$datadir/xauthority}"
+export XAUTHORITY="${XAUTHORITY:-${XDG_RUNTIME_DIR:-/run/user/$(id -u)}/xauthority}"
 touch -- "$XAUTHORITY"
 
 trap 'cleanup; exit "${xorg:-0}"' EXIT


### PR DESCRIPTION
Relatively minor PR to move the default location of `xauthority` to `$XDG_RUNTIME_DIR` rather than `$XDG_DATA_HOME` as per typical recommendation, hopefully to better comply with the current XDG Base Directory spec.

> `$XDG_RUNTIME_DIR` defines the base directory relative to which user-specific non-essential runtime files and other file objects (such as sockets, named pipes, ...) should be stored. The directory MUST be owned by the user, and he MUST be the only one having read and write access to it. Its Unix access mode MUST be 0700.
> 
> The lifetime of the directory MUST be bound to the user being logged in. It MUST be created when the user first logs in and if the user fully logs out the directory MUST be removed. If the user logs in more than once he should get pointed to the same directory, and it is mandatory that the directory continues to exist from his first login to his last logout on the system, and not removed in between. Files in the directory MUST not survive reboot or a full logout/login cycle.

If there are any problems with the current approach being proposed then please let me know.