### PR TITLE
Leave xauth default -- in the HOME

### DIFF
--- a/sx
+++ b/sx
@@ -24,7 +24,7 @@ cfgdir=${XDG_CONFIG_HOME:-$HOME/.config}/sx
 datadir=${XDG_DATA_HOME:-$HOME/.local/share}/sx
 mkdir -p -- "$cfgdir" "$datadir"
 
-export XAUTHORITY="${XAUTHORITY:-$datadir/xauthority}"
+export XAUTHORITY="${XAUTHORITY:-$HOME/.Xauthority}"
 touch -- "$XAUTHORITY"
 
 trap 'cleanup; exit "${xorg:-0}"' EXIT


### PR DESCRIPTION
Ugly as it is, it's up to X to decide where to put this. I found this issue when trying to use firejail. I suspect breakages might be possible when trying to forward X over a socket too. To avoid this kind of breakage I suggest leaving it at "$HOME/.Xauthority".

It is nice to put Xauthority in the data dir where it really should go, but it predates that standard.