### PR TITLE
sx: only create $datadir if $XAUTHORITY is unset

### DIFF
--- a/sx
+++ b/sx
@@ -21,8 +21,10 @@ tty=$(tty)
 tty=${tty#/dev/tty}
 
 cfgdir=${XDG_CONFIG_HOME:-$HOME/.config}/sx
+mkdir -p -- "$cfgdir"
+
 datadir=${XDG_DATA_HOME:-$HOME/.local/share}/sx
-mkdir -p -- "$cfgdir" "$datadir"
+mkdir -p -- "$([ "$XAUTHORITY" ] && dirname "$XAUTHORITY")" || mkdir -p -- "$datadir"
 
 export XAUTHORITY="${XAUTHORITY:-$datadir/xauthority}"
 touch -- "$XAUTHORITY"


### PR DESCRIPTION
In case of an alternative location for `$XAUTHORITY`, there isn't much need to keep creating a potentially empty directory.